### PR TITLE
Fix eBPF exit instruction

### DIFF
--- a/angr_platforms/ebpf/instrs_ebpf.py
+++ b/angr_platforms/ebpf/instrs_ebpf.py
@@ -757,7 +757,8 @@ class Exit64(Jump64Instruction):
     operation_bin = "1001"
 
     def compute_result(self):
-        self.jump(None, 0, JumpKind.Exit)  # irrelevant addr
+        # NOTE: BPF_EXIT actually means function return
+        self.jump(None, 0, JumpKind.Ret)  # irrelevant addr
 
 
 Jump = (


### PR DESCRIPTION
`exit` means "return" according to 
[Jump instructions](https://www.kernel.org/doc/html/latest/bpf/standardization/instruction-set.html#jump-instructions)

code | value | src | description | notes
-- | -- | -- | -- | --
BPF_EXIT | 0x9 | 0x0 | return | BPF_JMP only

and [Program-local functions](https://www.kernel.org/doc/html/latest/bpf/standardization/instruction-set.html#program-local-functions)
>  A `BPF_EXIT` within the program-local function will return to the caller.